### PR TITLE
docs: refocus profile around ai journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 <div align="center">
-  
+
 # 👋 Hi, I'm Adam Paterson
 
-[![Latest Version][ico-version]](https://github.com/adampaterson)
-[![Stability][ico-build]](https://github.com/adampaterson)
-[![Code Quality][ico-quality]](https://github.com/adampaterson)
-[![Licsense][ico-licence]](https://github.com/adampaterson)
-
-### Technical Solutions Architect & Principal Developer
+### AI/ML Solutions Architect & Principal Engineer
 
 </div>
 
 ## 🚀 About Me
 
-With over 12 years of experience crafting web applications, I'm passionate about building scalable, efficient e-commerce solutions. Currently, I'm helping merchants succeed at [IDHL](link-idhl) by delivering robust Ecommerce solutions with Adobe Commerce, BigCommerce and Shopify.
+I've been building production software since 2006, evolving from PHP engineer to principal technologist with a passion for AI,
+machine learning, and data-intensive systems. Today I design retrieval-augmented assistants, resilient data pipelines, and
+responsible ML practices that help teams ship trustworthy, next-generation experiences. Years spent leading Adobe Commerce,
+BigCommerce, and Shopify programmes taught me how to connect complex domain expertise with pragmatic automation—experience I now
+apply to AI-first initiatives at [IDHL](link-idhl).
 
 <div align="center">
 
@@ -23,67 +22,100 @@ With over 12 years of experience crafting web applications, I'm passionate about
 
 </div>
 
-### 🛠️ Tech Stack
+## 🧠 AI & Machine Learning Highlights
+
+- Architecting data pipelines that carry clean, observable signals from ingestion through model training, evaluation, and
+deployment.
+- Building retrieval-augmented copilots that unlock catalogues, documentation, and analytics through natural language
+interactions.
+- Embedding responsible AI guardrails—from dataset governance to human-in-the-loop feedback—so automation stays trustworthy.
+- Coaching cross-functional teams on prompt engineering, embeddings, and MLOps, enabling them to deliver AI features with
+confidence.
+
+## 🔄 Commerce Roots, AI Future
+
+- Modernising [Adobe Commerce][badge-adobe], [BigCommerce][badge-bigcommerce], and [Shopify][badge-shopify] implementations with
+AI-assisted merchandising, search, and support journeys.
+- Unifying [Akeneo](link-akeneo), ERP, and customer signals into knowledge graphs that drive richer storytelling and targeted
+automation.
+- Bringing AI observability and experimentation practices into delivery pipelines so every release is measurable and reliable.
+
+## 🧪 Explorations & Emerging Tech
+
+- Investigating how retrieval, orchestration, and evaluation stacks combine to support multi-modal customer experiences.
+- Mapping vector databases and agent frameworks to the realities of compliance-heavy environments.
+- Studying agentic workflows that can automate QA and operational runbooks without losing human oversight.
+
+## 🛠️ Tech Stack
 
 <details>
-<summary>E-commerce & Frameworks</summary>
+<summary>AI, Data & Automation</summary>
 
-![BigCommerce][badge-bigcommerce] ![Shopify][badge-shopify] ![Magento OS][badge-magento] ![Adobe Commerce][badge-adobe]
+![Python][badge-python] ![PyTorch][badge-pytorch] ![TensorFlow][badge-tensorflow] ![FastAPI][badge-fastapi]
+![LangChain][badge-langchain] ![OpenAI][badge-openai] ![Weights & Biases][badge-wandb]
+![Pandas][badge-pandas] ![Airflow][badge-airflow]
 
 </details>
 
 <details>
-<summary>Backend Technologies</summary>
+<summary>Backend & Architecture</summary>
 
-![PHP][badge-php] ![Laravel][badge-laravel] ![Symfony][badge-symfony] ![Python][badge-python] ![Django][badge-django] ![Ruby][badge-ruby] ![Rails][badge-ruby-rails]
+![PHP][badge-php] ![Laravel][badge-laravel] ![Symfony][badge-symfony] ![Python][badge-python]
+![Django][badge-django] ![Ruby][badge-ruby] ![Rails][badge-ruby-rails] ![FastAPI][badge-fastapi]
 
 </details>
 
 <details>
-<summary>Frontend & UI</summary>
+<summary>Commerce Platforms</summary>
+
+![Adobe Commerce][badge-adobe] ![Magento OS][badge-magento] ![BigCommerce][badge-bigcommerce] ![Shopify][badge-shopify]
+![Akeneo][badge-akeneo]
+
+</details>
+
+<details>
+<summary>Frontend & Experience</summary>
 
 ![Tailwind][badge-tailwind] ![Alpine][badge-alpine] ![React][badge-react] ![Wordpress][badge-wordpress]
 
 </details>
 
-## 🎯 Current Focus
+<details>
+<summary>Ops, Cloud & Data Engineering</summary>
 
-- 🔭 Working on: Ecommerce solutions with Adobe Commerce, BigCommerce and Shopify
-- 🌱 Learning: Machine Learning and AI
-- 👯 Open to: Collaboration on most projects
-- 💬 Ask me about: Adobe Commerce, BigCommerce, Shopify, Architecture, PHP or AI.
+![Docker][badge-docker] ![Kubernetes][badge-kubernetes] ![AWS][badge-aws] ![GCP][badge-gcp]
+![Azure][badge-azure] ![dbt][badge-dbt] ![Terraform][badge-terraform]
+
+</details>
+
+## 🎯 Focus & Collaboration
+
+- 🔭 I love designing AI accelerators that elevate cross-functional teams—from intelligent product discovery to generative
+support flows.
+- 🌱 Always sharpening my understanding of LLMOps, multi-agent orchestration, vector databases, and responsible AI governance.
+- 👯 Open to collaborations on applied AI, digital experience platforms, and full-stack prototypes that push technology forward.
+- 💬 Ask me about generative AI, solution architecture, Adobe Commerce, BigCommerce, Shopify, PHP, or Python.
 
 ## 🏆 Achievements
 
 [![An image of @adampaterson's Holopin badges, which is a link to view their full Holopin profile](https://holopin.me/adampaterson)](https://holopin.io/@adampaterson)
 
-## 💼 Expertise
-
-- **E-commerce Platforms**: Deep expertise in [Magento](link-magento) and Adobe Commerce
-- **PIM Systems**: Specialized knowledge in [Akeneo](link-akeneo)
-- **Framework Mastery**: Extensive experience with [Laravel](link-laravel) and [Symfony](link-symfony)
-- **Backend Development**: Advanced [PHP](link-php) development and architecture
-
 ## 📈 GitHub Stats
 
 <div align="center">
-  
+
 ![GitHub Stats](https://github-readme-stats.vercel.app/api?username=adam-paterson&show_icons=true&theme=radical)
 ![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=adam-paterson&layout=compact&theme=radical)
 [![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=adam-paterson&theme=radical)](https://git.io/streak-stats)
 
 </div>
 
-[ico-version]: https://img.shields.io/badge/Version-33-green?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white&logoWidth=20
-[ico-build]: https://img.shields.io/badge/Build-somewhat--stable-orange?style=for-the-badge&logo=travis-ci&logoColor=white&logoWidth=20
-[ico-quality]: https://img.shields.io/badge/Code%20Quality-A+-green?style=for-the-badge&logo=scrutinizer-ci&logoColor=white&logoWidth=20
-[ico-licence]: https://img.shields.io/badge/License-Divorced-green?style=for-the-badge&logo=tinder&logoColor=white&logoWidth=20
-[link-magento]: https://github.com/magento/magento2
-[link-akeneo]: https://github.com/akeneo/pim-community-dev
-[link-laravel]: https://github.com/laravel/laravel
-[link-symfony]: https://github.com/symfony/symfony
-[link-php]: https://github.com/topics/php
-[link-pinpoint]: https://www.pinpointdesigns.co.uk/
+## 🤝 Let's Build Together
+
+If you're exploring how AI can elevate commerce experiences—or you just want to jam on architecture, automation, or digital
+strategy—drop me a line. I'm always happy to trade ideas, pair on prototypes, or mentor teams embracing intelligent
+experiences.
+
 [badge-php]: https://img.shields.io/badge/PHP-777BB4?style=for-the-badge&logo=php&logoColor=white
 [badge-magento]: https://img.shields.io/badge/Magento_OS-EE672F?style=for-the-badge&logo=magento&logoColor=white
 [badge-adobe]: https://img.shields.io/badge/Adobe%20Commerce-FF0000?style=for-the-badge&logo=adobe&logoColor=white
@@ -92,10 +124,28 @@ With over 12 years of experience crafting web applications, I'm passionate about
 [badge-laravel]: https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white
 [badge-symfony]: https://img.shields.io/badge/Symfony-000?style=for-the-badge&logo=symfony&logoColor=white
 [badge-wordpress]: https://img.shields.io/badge/Wordpress-21759B?style=for-the-badge&logo=wordpress&logoColor=white
-[badge-tailwind]: https://img.shields.io/badge/Tailwind-56347C?style=for-the-badge&logo=tailwindcss&logoColor=white
+[badge-tailwind]: https://img.shields.io/badge/Tailwind-38BDF8?style=for-the-badge&logo=tailwindcss&logoColor=black
 [badge-alpine]: https://img.shields.io/badge/Alpine_JS-8BC0D0?style=for-the-badge&logo=alpinedotjs&logoColor=white
 [badge-react]: https://img.shields.io/badge/React-61DAFB?style=for-the-badge&logo=react&logoColor=black
 [badge-python]: https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white
 [badge-django]: https://img.shields.io/badge/Django-092E20?style=for-the-badge&logo=django&logoColor=white
 [badge-ruby]: https://img.shields.io/badge/Ruby-CC342D?style=for-the-badge&logo=ruby&logoColor=white
 [badge-ruby-rails]: https://img.shields.io/badge/Ruby_on_Rails-CC0000?style=for-the-badge&logo=ruby&logoColor=white
+[badge-pytorch]: https://img.shields.io/badge/PyTorch-EE4C2C?style=for-the-badge&logo=pytorch&logoColor=white
+[badge-tensorflow]: https://img.shields.io/badge/TensorFlow-FF6F00?style=for-the-badge&logo=tensorflow&logoColor=white
+[badge-fastapi]: https://img.shields.io/badge/FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white
+[badge-langchain]: https://img.shields.io/badge/LangChain-1B4D3E?style=for-the-badge
+[badge-openai]: https://img.shields.io/badge/OpenAI-412991?style=for-the-badge&logo=openai&logoColor=white
+[badge-wandb]: https://img.shields.io/badge/Weights_&_Biases-FFBE00?style=for-the-badge&logo=weightsandbiases&logoColor=black
+[badge-pandas]: https://img.shields.io/badge/Pandas-150458?style=for-the-badge&logo=pandas&logoColor=white
+[badge-airflow]: https://img.shields.io/badge/Apache_Airflow-017CEE?style=for-the-badge&logo=apacheairflow&logoColor=white
+[badge-akeneo]: https://img.shields.io/badge/Akeneo-4B2E83?style=for-the-badge&logoColor=white
+[badge-docker]: https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white
+[badge-kubernetes]: https://img.shields.io/badge/Kubernetes-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white
+[badge-aws]: https://img.shields.io/badge/AWS-FF9900?style=for-the-badge&logo=amazonaws&logoColor=white
+[badge-gcp]: https://img.shields.io/badge/Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white
+[badge-azure]: https://img.shields.io/badge/Azure-0078D4?style=for-the-badge&logo=microsoftazure&logoColor=white
+[badge-dbt]: https://img.shields.io/badge/dbt-FF694B?style=for-the-badge&logo=dbt&logoColor=white
+[badge-terraform]: https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white
+[link-idhl]: https://www.linkedin.com/company/idhl/
+[link-akeneo]: https://github.com/akeneo/pim-community-dev


### PR DESCRIPTION
## Summary
- refresh the about section to reflect nearly two decades of engineering experience with an AI/ML and data-pipeline focus
- reshape highlight sections to emphasise responsible AI, data systems, and forward-looking explorations while retaining commerce expertise
- reword collaboration notes to capture enduring interests without implying time-sensitive commitments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68c9257631e08327bbeb407ee1b14c58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated persona title to emphasize AI/ML.
  - Expanded About with AI-first narrative spanning assistants, data pipelines, responsible ML, and leadership experience.
  - Overhauled tech stack into AI-centric sections with clearer categories and new highlights.
  - Added Ops, Cloud & Data Engineering details; replaced achievements with Focus & Collaboration.
  - Introduced “Let’s Build Together” collaboration section.
  - Refreshed visuals: added numerous technology badges, adjusted styles, and reorganized badge placement.
  - Reordered content, links, and social references for cohesion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->